### PR TITLE
Use cross platform file paths

### DIFF
--- a/src/Knowzy_Shipping_WebApp/src/1. WebApp/Microsoft.Knowzy.WebApp/appsettings.json
+++ b/src/Knowzy_Shipping_WebApp/src/1. WebApp/Microsoft.Knowzy.WebApp/appsettings.json
@@ -18,9 +18,9 @@
     }
   },
   "AppSettings": {
-    "ProductJsonPath": "\\Data\\products.json",
-    "CustomerJsonPath": "\\Data\\customers.json",
-    "OrderJsonPath": "\\Data\\orders.json"
+    "ProductJsonPath": "Data/products.json",
+    "CustomerJsonPath": "Data/customers.json",
+    "OrderJsonPath": "Data/orders.json"
   },
   "ConnectionStrings": {
     "Knowzy": "Server=.\\SQLEXPRESS;Database=Knowzy;Trusted_Connection=True;MultipleActiveResultSets=true"

--- a/src/Knowzy_Shipping_WebApp/src/2. Services/Repositories/Microsoft.Knowzy.Repositories.Core/OrderRepositoryMock.cs
+++ b/src/Knowzy_Shipping_WebApp/src/2. Services/Repositories/Microsoft.Knowzy.Repositories.Core/OrderRepositoryMock.cs
@@ -170,9 +170,9 @@ namespace Microsoft.Knowzy.Repositories.Core
 
         private async Task Seed()
         {
-            var customerJsonPath = $"{_hostingEnvironment.WebRootPath}{_configuration["AppSettings:CustomerJsonPath"]}";
-            var productJsonPath = $"{_hostingEnvironment.WebRootPath}{_configuration["AppSettings:ProductJsonPath"]}";
-            var orderJsonPath = $"{_hostingEnvironment.WebRootPath}{_configuration["AppSettings:OrderJsonPath"]}";
+            var customerJsonPath = Path.Combine(_hostingEnvironment.WebRootPath, _configuration["AppSettings:CustomerJsonPath"]);
+            var productJsonPath = Path.Combine(_hostingEnvironment.WebRootPath, _configuration["AppSettings:ProductJsonPath"]);
+            var orderJsonPath = Path.Combine(_hostingEnvironment.WebRootPath, _configuration["AppSettings:OrderJsonPath"]);
 
             await SeedCustomers(customerJsonPath);
             await SeedProducts(productJsonPath);


### PR DESCRIPTION
The web app currently throws an exception for file not found when run inside a Linux container because it's looking for a Windows file path with backslashes

This changes to a slash & uses Path.Combine. Tested & working in VS on Windows and in a container on Docker / Kubernetes